### PR TITLE
Remove use of custom build of Cats

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ This mod adds a Scala library to Minecraft 26.1.2 with Forge and NeoForge.
           url = uri("https://maven.kotori316.com")
           content {
               includeModule("com.kotori316", "ScalableCatsForce".toLowerCase())
-              includeModule("org.typelevel", "cats-core_3")
-              includeModule("org.typelevel", "cats-kernel_3")
-              includeModule("org.typelevel", "cats-free_3")
           }
       }
   }
@@ -39,8 +36,9 @@ This mod adds a Scala library to Minecraft 26.1.2 with Forge and NeoForge.
   
       // Scala, no need to add Scala2 dependency since 3.8.3
       implementation('org.scala-lang:scala3-library_3:3.8.3')
-      // Add if you need this library. I use a modified version of Cats to avoid some module errors.
-      implementation('org.typelevel:cats-kernel_3:2.13.0-kotori')
+      // Add if you need this library.
+      // the runtime copy is bundled in the SLP jar.
+      implementation('org.typelevel:cats-kernel_3:2.13.0')
 
       // The language loader. You can put the jar to the mods dir instead of declaring in `build.gradle.kts`.
       runtimeOnly("com.kotori316:scalablecatsforce:4.0.4-mc26.1.2-3.8.3:dev") {
@@ -74,8 +72,10 @@ In this section, I note some points you should care.
 * [Scala](https://www.scala-lang.org/) - [GitHub](https://github.com/scala/scala) - is licenced under
   the [Apache License, Version 2.0](https://www.scala-lang.org/license/).
 * [Cats](https://typelevel.org/cats/) - [GitHub](https://github.com/typelevel/cats) - is licenced under
-  the [Licence](https://github.com/typelevel/cats/blob/master/COPYING).
-  * SLP uses [modified version of Cats](https://github.com/Kotori316/cats) to avoid module error.
+  the [License](https://github.com/typelevel/cats/blob/master/COPYING).
+  * SLP bundles the official Cats. NeoForge uses the jars as-is. The Forge jar removes the
+    Java-reserved-word packages (e.g. `cats.kernel.instances.byte`) from `cats-kernel`, because Forge's
+    module system rejects them while building the module layer at boot.
 
 [curse_forge]: https://www.curseforge.com/minecraft/mc-mods/scalable-cats-force
 [Modrinth]: https://modrinth.com/mod/scalable-cats-force

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ This mod adds a Scala library to Minecraft 26.1.2 with Forge and NeoForge.
       // Add Forge or NeoForge dependency as the platform requires
   
       // Scala, no need to add Scala2 dependency since 3.8.3
-      implementation('org.scala-lang:scala3-library_3:3.8.3')
+      implementation('org.scala-lang:scala3-library_3:3.8.4')
       // Add if you need this library.
       // the runtime copy is bundled in the SLP jar.
       implementation('org.typelevel:cats-kernel_3:2.13.0')
 
       // The language loader. You can put the jar to the mods dir instead of declaring in `build.gradle.kts`.
-      runtimeOnly("com.kotori316:scalablecatsforce:4.0.4-mc26.1.2-3.8.3:dev") {
+      runtimeOnly("com.kotori316:scalablecatsforce:4.0.5-mc26.1.2-3.8.4:dev") {
           transitive(false)
       }
   }
@@ -51,7 +51,7 @@ This mod adds a Scala library to Minecraft 26.1.2 with Forge and NeoForge.
     to "compileOnly" and add slp mod in the mods directory.**
   * Change the library version if needed.
     * See detail pages in CurseForge or Modrinth to get which library version is included in the Jar file.
-  * From 26.1.2 version, SLP includes Scala 3.8.3
+  * From 26.1.2 version, SLP includes Scala 3.8.4
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ In this section, I note some points you should care.
   in `BlockPos` and `Vec3i`, and the return types are different. So, the compiler can't determine which method to call.
   To resolve this issue, specify the return type as follows. `val offsetPos: BlockPos = pos.relative(direction)`
 
+3. On Forge, do not import the per-primitive Cats convenience packages
+   `cats.kernel.instances.{byte, char, short, int, long, float, double, boolean}` directly.
+
+* These packages are named after Java reserved words, so the Forge jar drops them (see the API section). Code such as
+  `import cats.kernel.instances.int.*` compiles against the official Cats but throws `NoClassDefFoundError:
+  cats/kernel/instances/int/package$` at runtime on Forge. The instances are still available via `cats.implicits.*`,
+  `cats.syntax.*`, `cats.kernel.instances.all.*`, or `cats.kernel.instances.<Type>Instances` (e.g.
+  `cats.kernel.instances.IntInstances`). NeoForge bundles the jars as-is and is unaffected.
+
 ## API
 
 * [Scala](https://www.scala-lang.org/) - [GitHub](https://github.com/scala/scala) - is licenced under

--- a/build-logic/common/src/main/kotlin/com.kotori316.common.java.gradle.kts
+++ b/build-logic/common/src/main/kotlin/com.kotori316.common.java.gradle.kts
@@ -31,15 +31,6 @@ repositories {
         }
     }
     mavenCentral()
-    maven {
-        name = "Kotori316"
-        url = uri("https://maven.kotori316.com")
-        content {
-            includeModule("org.typelevel", "cats-core_3")
-            includeModule("org.typelevel", "cats-kernel_3")
-            includeModule("org.typelevel", "cats-free_3")
-        }
-    }
 }
 
 val mockitoAgent = configurations.create("mockitoAgent")

--- a/example/26.1-forge/build.gradle.kts
+++ b/example/26.1-forge/build.gradle.kts
@@ -68,6 +68,8 @@ val forgeJarJarOutput: Provider<RegularFile> = project(":forge-26.1.2").tasks
 dependencies {
     implementation(minecraft.dependency(libs.forge260102))
     compileOnly(libs.scala3)
+    // Cats is provided at runtime by the SLP jarJar fat jar. Only needed for compilation here.
+    compileOnly(libs.bundles.cats) { isTransitive = false }
     // Use the jarJar fat jar at runtime so Forge can find kotori_scala with the correct version
     // and load the bundled scala/cats jars via JarJar
     runtimeOnly(files(forgeJarJarOutput))

--- a/example/26.1-forge/build.gradle.kts
+++ b/example/26.1-forge/build.gradle.kts
@@ -50,15 +50,6 @@ repositories {
     maven(fg.forgeMaven)
     maven(fg.minecraftLibsMaven)
     mavenCentral()
-    maven {
-        name = "Kotori316"
-        url = uri("https://maven.kotori316.com")
-        content {
-            includeModule("org.typelevel", "cats-core_3")
-            includeModule("org.typelevel", "cats-kernel_3")
-            includeModule("org.typelevel", "cats-free_3")
-        }
-    }
 }
 
 val forgeJarJarOutput: Provider<RegularFile> = project(":forge-26.1.2").tasks

--- a/example/26.1-forge/src/main/scala/com/kotori316/slp/example/ScalaExampleMod.scala
+++ b/example/26.1-forge/src/main/scala/com/kotori316/slp/example/ScalaExampleMod.scala
@@ -18,11 +18,13 @@ class ScalaExampleMod(context: FMLJavaModLoadingContext, container: ModContainer
 
   private def setUp(event: FMLCommonSetupEvent): Unit = {
     ScalaExampleMod.LOGGER.info(s"Hello from Scala Example Mod(${container.getModId}) on ${event.getClass.getName}!")
+    ScalaExampleMod.LOGGER.info(s"Cats works on startup: ${ScalaExampleMod.catsDemo}")
   }
 
   private def registerDataGen(event: GatherDataEvent): Unit = {
     ScalaExampleMod.LOGGER.info(s"Starting data generation in ${SharedConstants.getCurrentVersion.name} Forge ${ForgeVersion.getVersion}")
     ScalaExampleMod.LOGGER.info("Start data generation for Scala Example Mod. Input: {}", event.getInputs)
+    ScalaExampleMod.LOGGER.info(s"Cats works in data generation: ${ScalaExampleMod.catsDemo}")
   }
 }
 
@@ -30,4 +32,25 @@ private object ScalaExampleMod {
   @static
   final val MOD_ID = "slp_examples"
   final val LOGGER = LoggerFactory.getLogger(MOD_ID)
+
+  /**
+   * Exercises classes from all three bundled Cats modules to confirm the official
+   * Cats binary loads correctly inside the Forge module layer at runtime.
+   *   - cats-core:   [[cats.data.NonEmptyList]]
+   *   - cats-kernel: [[cats.kernel.Monoid]] (via the `combineAll` syntax)
+   *   - cats-free:   [[cats.free.Free]]
+   */
+  private def catsDemo: String = {
+    import cats.Id
+    import cats.arrow.FunctionK
+    import cats.data.NonEmptyList
+    import cats.free.Free
+    import cats.implicits.*
+
+    val nel = NonEmptyList.of(1, 2, 3)
+    val sum = nel.toList.combineAll
+    val program = Free.pure[Id, Int](sum).map(_ + nel.head)
+    val freeResult = program.foldMap(FunctionK.id[Id])
+    s"NonEmptyList=${nel.toList.mkString(",")}, Monoid sum=$sum, Free result=$freeResult"
+  }
 }

--- a/example/26.1-neoforge/build.gradle.kts
+++ b/example/26.1-neoforge/build.gradle.kts
@@ -37,6 +37,8 @@ repositories {
 
 dependencies {
     compileOnly(libs.scala3)
+    // Cats is provided at runtime by the SLP jar (JarInJar). Only needed for compilation here.
+    compileOnly(libs.bundles.cats) { isTransitive = false }
     runtimeOnly(project(":neoforge-26.1.2")) {
         isTransitive = false
     }

--- a/example/26.1-neoforge/src/main/scala/com/kotori316/slp/example/ScalaExampleMod.scala
+++ b/example/26.1-neoforge/src/main/scala/com/kotori316/slp/example/ScalaExampleMod.scala
@@ -21,6 +21,7 @@ class ScalaExampleMod(modEventBus: IEventBus, container: ModContainer) {
 
   private def setUp(event: FMLCommonSetupEvent): Unit = {
     ScalaExampleMod.LOGGER.info(s"Hello from Scala Example Mod(${container.getModId}) on ${event.toString}!")
+    ScalaExampleMod.LOGGER.info(s"Cats works on startup: ${ScalaExampleMod.catsDemo}")
   }
 
   private def register(event: RegisterEvent): Unit = {
@@ -37,9 +38,31 @@ object ScalaExampleMod {
   final val MOD_ID = "slp_examples"
   final val LOGGER = LoggerFactory.getLogger(MOD_ID)
 
+  /**
+   * Exercises classes from all three bundled Cats modules to confirm the official
+   * Cats binary loads correctly inside the (Neo)Forge module layer at runtime.
+   *   - cats-core:   [[cats.data.NonEmptyList]]
+   *   - cats-kernel: [[cats.kernel.Monoid]] (via the `combineAll` syntax)
+   *   - cats-free:   [[cats.free.Free]]
+   */
+  private def catsDemo: String = {
+    import cats.Id
+    import cats.arrow.FunctionK
+    import cats.data.NonEmptyList
+    import cats.free.Free
+    import cats.implicits.*
+
+    val nel = NonEmptyList.of(1, 2, 3)
+    val sum = nel.toList.combineAll
+    val program = Free.pure[Id, Int](sum).map(_ + nel.head)
+    val freeResult = program.foldMap(FunctionK.id[Id])
+    s"NonEmptyList=${nel.toList.mkString(",")}, Monoid sum=$sum, Free result=$freeResult"
+  }
+
   //noinspection UnstableApiUsage
   private def gameTest(helper: GameTestHelper): Unit = {
     ScalaExampleMod.LOGGER.info(s"Running game test in ${SharedConstants.getCurrentVersion.name} NeoForge ${NeoForgeVersion.getVersion}")
+    ScalaExampleMod.LOGGER.info(s"Cats works in game test: ${ScalaExampleMod.catsDemo}")
     helper.succeed()
   }
 }

--- a/forge-26.1.2/build.gradle.kts
+++ b/forge-26.1.2/build.gradle.kts
@@ -38,10 +38,12 @@ jarJar {
 // (cats.kernel.instances.{byte,char,short,int,long,float,double,boolean}). These are legal in
 // Scala but Forge's securejarhandler rejects them while building the module layer at boot
 // ("Invalid package name: 'byte' is not a Java identifier"), before any mod/coremod/mixin runs.
-// NeoForge's fork tolerates them, but Forge does not. These packages only contain
-// `import cats.kernel.instances.byte.*` convenience shims and are referenced by nothing inside
-// cats-core/kernel/free, so we drop them from the bundled jar to make it JPMS-valid. Instances
-// remain available via cats.implicits.*, cats.syntax.*, and cats.kernel.instances.<Type>Instances.
+// NeoForge's fork tolerates them, but Forge does not. These packages only contain `package object`
+// convenience shims (for `import cats.kernel.instances.byte.*`). No class header references them, so
+// dropping them does not break class loading; a few kernel companions (Eq$, Semigroup$, SortedSetOrder,
+// ...) do reference them, but only in method-body forwarders that normal implicit resolution never picks.
+// So we drop them from the bundled jar to make it JPMS-valid. Instances remain available via
+// cats.implicits.*, cats.syntax.*, cats.kernel.instances.all.*, and cats.kernel.instances.<Type>Instances.
 tasks.named("jarJar", org.gradle.jvm.tasks.Jar::class) {
     doLast {
         stripReservedCatsPackages(archiveFile.get().asFile)

--- a/forge-26.1.2/build.gradle.kts
+++ b/forge-26.1.2/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.ByteArrayOutputStream
+import java.util.zip.*
+
 plugins {
     id("com.kotori316.common.java")
     id("com.kotori316.common.publish")
@@ -29,6 +32,20 @@ repositories {
 
 jarJar {
     register()
+}
+
+// The official cats-kernel ships package objects in Java-reserved-word packages
+// (cats.kernel.instances.{byte,char,short,int,long,float,double,boolean}). These are legal in
+// Scala but Forge's securejarhandler rejects them while building the module layer at boot
+// ("Invalid package name: 'byte' is not a Java identifier"), before any mod/coremod/mixin runs.
+// NeoForge's fork tolerates them, but Forge does not. These packages only contain
+// `import cats.kernel.instances.byte.*` convenience shims and are referenced by nothing inside
+// cats-core/kernel/free, so we drop them from the bundled jar to make it JPMS-valid. Instances
+// remain available via cats.implicits.*, cats.syntax.*, and cats.kernel.instances.<Type>Instances.
+tasks.named("jarJar", org.gradle.jvm.tasks.Jar::class) {
+    doLast {
+        stripReservedCatsPackages(archiveFile.get().asFile)
+    }
 }
 
 dependencies {
@@ -169,4 +186,93 @@ fun createChangelog(): String {
 
 ext["archivesBaseName"] = base.archivesName.get()
 ext["generalDescription"] = createChangelog()
+
+/**
+ * Package directories named after Java reserved words that the official cats-kernel ships and
+ * that Forge's module layer cannot accept.
+ */
+val reservedCatsPackages = listOf("byte", "char", "short", "int", "long", "float", "double", "boolean")
+    .map { "cats/kernel/instances/$it/" }
+
+/**
+ * Rewrites the JarInJar fat jar in place, replacing the nested `cats-kernel_3-*.jar` with a copy
+ * that has the reserved-word package directories removed. Compression method is preserved per
+ * entry so the JarInJar locator keeps reading the nested jars unchanged.
+ */
+fun stripReservedCatsPackages(fatJar: File) {
+    val tmp = File(fatJar.parentFile, "${fatJar.name}.stripping")
+    var rewrote = false
+    ZipFile(fatJar).use { zf ->
+        ZipOutputStream(tmp.outputStream().buffered()).use { zos ->
+            for (entry in zf.entries()) {
+                val data = if (entry.name.matches(Regex("META-INF/jarjar/cats-kernel_3-.*\\.jar"))) {
+                    rewrote = true
+                    cleanNestedJar(zf.getInputStream(entry).readBytes())
+                } else {
+                    zf.getInputStream(entry).readBytes()
+                }
+                copyZipEntry(zos, entry.name, data, entry.method, entry.time)
+            }
+        }
+    }
+    if (!rewrote) {
+        tmp.delete()
+        throw GradleException("stripReservedCatsPackages: no nested cats-kernel jar found in ${fatJar.name}")
+    }
+    fatJar.delete()
+    tmp.renameTo(fatJar)
+    logger.lifecycle("Stripped reserved-word cats-kernel packages from ${fatJar.name}")
+}
+
+/**
+ * Returns the bytes of [jarBytes] with all [reservedCatsPackages] entries removed.
+ *
+ * Read straight from memory with [ZipInputStream]: the cats jars are entirely `DEFLATED`, and even
+ * `STORED` entries always carry their `size`/`crc` in the local header (data descriptors are only
+ * allowed for `DEFLATED`), so streaming is reliable here. ([java.util.jar.JarInputStream] is
+ * intentionally not used because it swallows `META-INF/MANIFEST.MF` from the entry iteration.)
+ */
+fun cleanNestedJar(jarBytes: ByteArray): ByteArray {
+    val out = ByteArrayOutputStream(jarBytes.size)
+    ZipInputStream(jarBytes.inputStream()).use { zis ->
+        ZipOutputStream(out).use { zos ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val e = entry
+                if (reservedCatsPackages.none { e.name.startsWith(it) }) {
+                    copyZipEntry(zos, e.name, zis.readBytes(), e.method, e.time)
+                }
+                entry = zis.nextEntry
+            }
+        }
+    }
+    return out.toByteArray()
+}
+
+/**
+ * Writes [data] to [zos] under [name], preserving the original compression [method] and [time].
+ *
+ * Built from a name-only [ZipEntry] (whose `size`/`crc`/`compressedSize` start at `-1`, i.e.
+ * "unknown") rather than the `ZipEntry(ZipEntry)` copy constructor, because [data] is re-compressed
+ * here and those size fields must be recomputed. The copy constructor would carry over the source's
+ * `size`/`crc`/`compressedSize`, and for a `DEFLATED` entry that makes [ZipOutputStream] take the
+ * "sizes already known" path and validate them in `closeEntry()` against the freshly deflated
+ * output, throwing `ZipException: invalid entry compressed size`. They cannot be reset
+ * either: `setSize(-1)` and `setCrc(-1)` throw `IllegalArgumentException` (only `setCompressedSize(-1)`
+ * is allowed). A fresh entry sidesteps all of that; for `STORED` we must supply the sizes ourselves.
+ * (`extra` fields / entry comments are dropped, which is irrelevant to class loading.)
+ */
+fun copyZipEntry(zos: ZipOutputStream, name: String, data: ByteArray, method: Int, time: Long) {
+    val out = ZipEntry(name)
+    out.method = method
+    out.time = time
+    if (method == ZipEntry.STORED) {
+        out.size = data.size.toLong()
+        out.compressedSize = data.size.toLong()
+        out.crc = CRC32().apply { update(data) }.value
+    }
+    zos.putNextEntry(out)
+    zos.write(data)
+    zos.closeEntry()
+}
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,8 @@ forge260102="26.1.2-64.0.9"
 neo260102="26.1.2.75"
 # https://mvnrepository.com/artifact/org.scala-lang/scala-library
 scala = "3.8.4"
-cats = "2.13.0-kotori"
+# https://mvnrepository.com/artifact/org.typelevel/cats-core
+cats = "2.13.0"
 # https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
 jupiter-api = "6.1.0"
 # https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher


### PR DESCRIPTION
Use official Cats instead of manually-built version.

   Until now SLP bundled a custom fork of Cats (`2.13.0-kotori`) to avoid module errors when Forge builds its module layer. This PR switches to the official `org.typelevel` Cats `2.13.0` from Maven Central and verifies it works on both loaders.

   ## Background

   The official `cats-kernel_3` ships package objects in packages named after Java reserved words (`cats.kernel.instances.{byte, char, short, int, long, float, double, boolean}`). They are legal in Scala, but Forge's `securejarhandler` rejects them while constructing the module layer at boot — before any mod / coremod / mixin runs:

   ```
   java.lang.IllegalArgumentException: cats.kernel.instances.byte: Invalid package name: 'byte' is not a Java identifier
       at cpw.mods.jarhandling.impl.SimpleJarMetadata.descriptor(...)
       at cpw.mods.modlauncher.ModuleLayerHandler.build(...)
   ```

   NeoForge's fork of securejarhandler tolerates these packages, so NeoForge works with the official jars unchanged. Forge does not, which is the reason the custom fork existed.

   ## Changes

   - Switch to official Cats `2.13.0` (`gradle/libs.versions.toml`).
   - **NeoForge**: bundle the official jars as-is.
   - **Forge**: the `jarJar` task now strips the reserved-word package directories from the nested `cats-kernel` jar so it is JPMS-valid. Those directories contain only `package object` convenience shims (for `import cats.kernel.instances.byte.*`). No class header in cats-core / cats-kernel / cats-free references them, so dropping them does not break class loading; a few kernel companions (`Eq$`, `Semigroup$`, `SortedSetOrder`, …) do reference them, but only in method-body forwarders that normal implicit resolution never picks. The instances stay available via `cats.implicits.*`, `cats.syntax.*`, `cats.kernel.instances.all.*`, and `cats.kernel.instances.<Type>Instances`.
   - **Forge caveat**: because the bundled jar drops these packages while the official Cats (used at compile time) keeps them, `import cats.kernel.instances.{byte,char,short,int,long,float,double,boolean}.*` compiles but throws `NoClassDefFoundError` at runtime on Forge. NeoForge is unaffected. Documented in the README limitations.
   - Remove the now-unused custom Cats Maven repository declarations (Cats resolves from Maven Central).
   - Add Cats usage (cats-core / cats-kernel / cats-free) to the example mods so startup exercises both Scala and Cats.
   - Update README (official Cats, Scala 3.8.4).

   ## Verification

   - `./gradlew test build publishToMavenLocal checkBinaryContent` — green on both platforms.
   - NeoForge `runGameTestServer` — all required tests pass.
   - Forge `runData` — boots with no module error.
   - Cats runs at runtime on both loaders: `NonEmptyList=1,2,3, Monoid sum=6, Free result=7`.
